### PR TITLE
Fix user reference

### DIFF
--- a/Markdown.Editor.js
+++ b/Markdown.Editor.js
@@ -1816,7 +1816,7 @@
 
     commandProto.doUserReference = function (chunk, postProcessing) {
         chunk.before = chunk.before + "[user:";
-        chunk.after = chunk.after + "]";
+        chunk.after = "]" + chunk.after;
         if (!chunk.selection) {
             chunk.selection = this.getString("userexample");
         }


### PR DESCRIPTION
before: `]` is put at the very end
after: `]` is put after the user reference